### PR TITLE
Removed Home Directory assumption

### DIFF
--- a/postinstall.sh
+++ b/postinstall.sh
@@ -13,10 +13,10 @@ then
     #from within terminal in the recovery mode (cmd+R while booting)
     ##CoreServices Boot.efi
     sudo chflags nouchg /System/Library/CoreServices/boot.efi
-    sudo cp ~/boot.efi /System/Library/CoreServices/
+    sudo cp ./boot.efi /System/Library/CoreServices/
     sudo chflags uchg /System/Library/CoreServices/boot.efi
     ##Copy to /usr
-    sudo cp ~/boot.efi /usr/standalone/i386
+    sudo cp ./boot.efi /usr/standalone/i386
     ##To-Do: Copy to Recovery Partition
 else
     exit


### PR DESCRIPTION
The script assumed that it was unziping myfile.zip in the user's home directory which causes a file not found error in the script when trying to copy the contents, e.g. boot.efi into it's proper position if myfile.zip isn't actually unzipped in the user's home directory
