### PR TITLE
postinstall: follow 301 redirects when getting EFI

### DIFF
--- a/postinstall.sh
+++ b/postinstall.sh
@@ -7,7 +7,7 @@ read -r -p "Continue making this disk unbootable on this system? [y/N] " respons
 if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
 then
     #Get black version of EFI boot file
-    curl -o myfile.zip http://forums.macrumors.com/attachments/boot-black-zip.511172/ ; unzip myfile.zip; rm myfile.zip
+    curl -L -o myfile.zip http://forums.macrumors.com/attachments/boot-black-zip.511172/ ; unzip myfile.zip; rm myfile.zip
     #Install Boot.efi
     #NOTE: You will Need to Have Disabled SIP Using csrutil disable; reboot
     #from within terminal in the recovery mode (cmd+R while booting)


### PR DESCRIPTION
macrumors has moved the archive, but helpfully has a 301. Using -L causes cURL to follow the redirect so you get a .zip instead of the HTML telling you how to find the .zip.

Thanks for the script!